### PR TITLE
[FIX] deprecation alias method chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pkg
 doc
 Manifest
 *.gem
+.idea

--- a/easy_roles.gemspec
+++ b/easy_roles.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{easy_roles}
-  s.version = "2.0.1"
+  s.version = "2.0.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = [%q{Platform45}]

--- a/easy_roles.gemspec
+++ b/easy_roles.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{easy_roles}
-  s.version = "2.0.0.beta2"
+  s.version = "2.0.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = [%q{Platform45}]

--- a/lib/easy_roles.rb
+++ b/lib/easy_roles.rb
@@ -4,8 +4,11 @@ module EasyRoles
   extend ActiveSupport::Concern
   
   included do |base|
-    base.send :alias_method_chain, :method_missing, :roles
-    base.send :alias_method_chain, :respond_to?, :roles
+    base.alias_method :method_missing_without_roles, :method_missing
+    base.alias_method :method_missing, :method_missing_with_roles
+
+    base.alias_method :respond_to_without_roles?, :respond_to?
+    base.alias_method :respond_to?, :respond_to_with_roles?
   end
 
   ALLOWED_METHODS = [:serialize, :bitmask]
@@ -43,7 +46,7 @@ module EasyRoles
     if match && respond_to?('has_role?')
       true
     else
-      respond_to_without_roles?(method_id, include_private = false)
+      respond_to_without_roles?(method_id, include_private)
     end
   end
 end


### PR DESCRIPTION
This PR includes the fix of deprecation `alias_method_chain` and fix in a method.